### PR TITLE
Project name in multiple subprojects build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 enablePlugins(SbtPlugin)
 
-version := "0.2.1"
+version := "0.2.2"
 scalaVersion := "2.12.6"
 organization := "com.github.cb372"
 description := "An sbt plugin to check that your project does not directly depend on any transitive dependencies for compilation"

--- a/example/project/build.properties
+++ b/example/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.1
+sbt.version=1.2.3

--- a/example/project/plugins.sbt
+++ b/example/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.github.cb372" % "sbt-explicit-dependencies" % "0.2.1")
+addSbtPlugin("com.github.cb372" % "sbt-explicit-dependencies" % "0.2.2")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.1
+sbt.version=1.2.3

--- a/src/main/scala/explicitdeps/ExplicitDepsPlugin.scala
+++ b/src/main/scala/explicitdeps/ExplicitDepsPlugin.scala
@@ -34,6 +34,7 @@ object ExplicitDepsPlugin extends AutoPlugin {
   )
 
   lazy val undeclaredCompileDependenciesTask = Def.task {
+    val projectName = name.value
     val compileAnalysis = compile.in(Compile).value.asInstanceOf[Analysis]
     val libraryDeps = libraryDependencies.value
     val scalaBinaryVer = scalaBinaryVersion.value
@@ -46,10 +47,10 @@ object ExplicitDepsPlugin extends AutoPlugin {
     if (undeclaredCompileDependencies.nonEmpty) {
       val sorted = undeclaredCompileDependencies.toList.sortBy(dep => s"${dep.organization} ${dep.name}")
       log.warn(
-        s"""The project depends on the following libraries for compilation but they are not declared in libraryDependencies:
-          |${sorted.mkString("\n")}""".stripMargin)
+        s"""$projectName >>> The project depends on the following libraries for compilation but they are not declared in libraryDependencies:
+          | - ${sorted.mkString("\n - ")}""".stripMargin)
     } else {
-      log.info("The project explicitly declares all the libraries that it directly depends on for compilation. Good job!")
+      log.info(s"$projectName >>> The project explicitly declares all the libraries that it directly depends on for compilation. Good job!")
     }
 
     undeclaredCompileDependencies
@@ -62,6 +63,7 @@ object ExplicitDepsPlugin extends AutoPlugin {
   }
 
   lazy val unusedCompileDependenciesTask = Def.task {
+    val projectName = name.value
     val compileAnalysis = compile.in(Compile).value.asInstanceOf[Analysis]
     val libraryDeps = libraryDependencies.value
     val scalaBinaryVer = scalaBinaryVersion.value
@@ -74,10 +76,10 @@ object ExplicitDepsPlugin extends AutoPlugin {
     if (unusedCompileDependencies.nonEmpty) {
       val sorted = unusedCompileDependencies.toList.sortBy(dep => s"${dep.organization} ${dep.name}")
       log.warn(
-        s"""The following libraries are declared in libraryDependencies but are not needed for compilation:
-           |${sorted.mkString("\n")}""".stripMargin)
+        s"""$projectName >>> The following libraries are declared in libraryDependencies but are not needed for compilation:
+           | - ${sorted.mkString("\n - ")}""".stripMargin)
     } else {
-      log.info("The project has no unused dependencies declared in libraryDependencies. Good job!")
+      log.info(s"$projectName >>> The project has no unused dependencies declared in libraryDependencies. Good job!")
     }
 
     unusedCompileDependencies


### PR DESCRIPTION
Address https://github.com/cb372/sbt-explicit-dependencies/issues/3. It will print something like
```
sbt:log-effect> undeclaredCompileDependencies
[info] log-effect >>> The project explicitly declares all the libraries that it directly depends on for compilation. Good job!
[info] log-effect-core >>> The project explicitly declares all the libraries that it directly depends on for compilation. Good job!
[warn] log-effect-zio >>> The project depends on the following libraries for compilation but they are not declared in libraryDependencies:
[warn]  - "org.log4s" %% "log4s" % "1.6.1"
[warn] log-effect-fs2 >>> The project depends on the following libraries for compilation but they are not declared in libraryDependencies:
[warn]  - "org.log4s" %% "log4s" % "1.6.1"
[warn]  - "org.typelevel" %% "cats-core" % "1.3.1"
[success] Total time: 2 s, completed 18-Sep-2018 12:25:4
```
```
sbt:log-effect> unusedCompileDependencies
[warn] log-effect >>> The following libraries are declared in libraryDependencies but are not needed for compilation:
[warn]  - "com.github.ghik" %% "silencer-lib" % "1.2"
[warn]  - "com.github.ghik" %% "silencer-plugin" % "1.2"
[warn]  - "org.spire-math" %% "kind-projector" % "0.9.7"
[warn] log-effect-core >>> The following libraries are declared in libraryDependencies but are not needed for compilation:
[warn]  - "com.github.ghik" %% "silencer-plugin" % "1.2"
[warn]  - "org.spire-math" %% "kind-projector" % "0.9.7"
[warn] log-effect-zio >>> The following libraries are declared in libraryDependencies but are not needed for compilation:
[warn]  - "com.github.ghik" %% "silencer-lib" % "1.2"
[warn]  - "com.github.ghik" %% "silencer-plugin" % "1.2"
[warn]  - "org.spire-math" %% "kind-projector" % "0.9.7"
[warn] log-effect-fs2 >>> The following libraries are declared in libraryDependencies but are not needed for compilation:
[warn]  - "com.github.ghik" %% "silencer-lib" % "1.2"
[warn]  - "com.github.ghik" %% "silencer-plugin" % "1.2"
[warn]  - "org.spire-math" %% "kind-projector" % "0.9.7"
[success] Total time: 0 s, completed 18-Sep-2018 12:26:06
```
and for the example
```
sbt:example> undeclaredCompileDependencies
[warn] example >>> The project depends on the following libraries for compilation but they are not declared in libraryDependencies:
[warn]  - "com.chuusai" %% "shapeless" % "2.3.3"
[warn]  - "com.google.guava" % "guava" % "26.0-jre"
[warn]  - "org.typelevel" %% "cats-core" % "1.2.0"
[warn]  - "org.typelevel" %% "cats-effect" % "0.10.1"
[success] Total time: 0 s, completed 18-Sep-2018 13:05:11
```