### PR TITLE
Make the matching for scala-library more lenient

### DIFF
--- a/example/build.sbt
+++ b/example/build.sbt
@@ -1,4 +1,5 @@
 scalaVersion := "2.12.6"
+crossScalaVersions := List("2.11.12", scalaVersion.value)
 name := "example"
 
 libraryDependencies ++= Seq(

--- a/src/main/scala/explicitdeps/ExplicitDepsPlugin.scala
+++ b/src/main/scala/explicitdeps/ExplicitDepsPlugin.scala
@@ -96,7 +96,7 @@ object ExplicitDepsPlugin extends AutoPlugin {
       compileAnalysis.relations.allLibraryDeps
         .filter(_.getName.endsWith(".jar"))
         .filterNot(_.getName == "rt.jar") // Java runtime
-        .filterNot(_.getName == "scala-library.jar")
+        .filterNot(_.getName matches "scala-library.*\\.jar")
 
     val compileDependencies = compileDependencyJarFiles
       .flatMap(BoringStuff.jarFileToDependency(scalaBinaryVersion, log))


### PR DESCRIPTION
Under normal circumstances sbt will use a file called `scala-library.jar` under `~/.sbt/boot/`. But when cross-compiling, it uses a file downloaded using Ivy/Coursier, which might have the version number in the filename.

Fixes #9