### PR TITLE
More accurately filter compile config library deps

### DIFF
--- a/example/build.sbt
+++ b/example/build.sbt
@@ -10,7 +10,7 @@ libraryDependencies ++= Seq(
   "org.http4s" %% "http4s-circe" % "0.18.16",
 
   // this brings in cats-effect and cats-core as transitive dependencies, which are used directly for compilation
-  "org.tpolecat" %% "doobie-postgres" % "0.5.3",
+  "org.tpolecat" %% "doobie-postgres" % "0.5.3" % "compile",
 
   // this is just an example of a dependency that is irrelevant to the sbt plugin
   "org.postgresql" % "postgresql" % "42.2.5",
@@ -23,3 +23,7 @@ libraryDependencies ++= Seq(
   // and it is depended on directly for compilation
   "org.typelevel" %% "cats-core" % "1.2.0" % Test
 )
+
+// This adds a dependency to libraryDependencies, which the plugin needs to take into account
+// in order to correctly calculate unused dependencies
+addCompilerPlugin("org.spire-math" % "kind-projector" % "0.9.7" cross CrossVersion.binary)

--- a/example/src/main/scala/foo/Example.scala
+++ b/example/src/main/scala/foo/Example.scala
@@ -1,6 +1,7 @@
 package foo
 
 import cats.data._
+import cats.instances.either._
 import shapeless._
 import cats.effect.IO
 import org.http4s.server.blaze._
@@ -21,5 +22,8 @@ object Example {
 
   // depends on Guava (a Java lib with a version containing a dash)
   val hash = com.google.common.hash.Hashing.adler32().hashInt(12345)
+
+  // uses the kind-projector compiler plugin
+  val eitherMonad = cats.Monad[Either[String, ?]]
 
 }


### PR DESCRIPTION
When looking at `libraryDependencies`, only select those that either have no configuration specified or are explicitly for the project's `compile` configuration.

Compiler plugins are added to a special `plugin` configuration, so this will correctly filter those out.

Fixes #13 