### PR TITLE
Handle Ivy local directory structure when looking for ivy.xml

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import ReleaseTransformations._
 
 enablePlugins(SbtPlugin)
-crossSbtVersions := Seq("0.13.17", "1.2.3")
+crossSbtVersions := Seq("0.13.17", "1.2.8")
 
 scalaVersion := "2.12.6"
 organization := "com.github.cb372"
@@ -16,7 +16,7 @@ releaseProcess := Seq[ReleaseStep](
   checkSnapshotDependencies,
   inquireVersions,
   runClean,
-  //releaseStepCommandAndRemaining("^ test"), TODO write some damn tests
+  releaseStepCommandAndRemaining("^ scripted"),
   setReleaseVersion,
   commitReleaseVersion,
   tagRelease,


### PR DESCRIPTION
This means we correctly handle dependencies on locally-published jars.

Fixes #22