### PR TITLE
Add support for filtering results

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,22 @@ sbt:example> unusedCompileDependenciesTest
 [error] Total time: 0 s, completed 01-Oct-2018 00:18:00
 ```
 
+### Filtering the results
+
+If the result of either `undeclaredCompileDependencies` or
+`unusedCompileDependencies` contains any dependencies you don't care about, you
+can exclude them using the `undeclaredCompileDependenciesFilter` and
+`unusedCompileDependenciesFilter` settings.
+
+For example:
+
+```
+unusedCompileDependenciesFilter -= moduleFilter("org.scalaz", "scalaz")
+```
+
+Note: If you're filtering things out because you think the plugin is returning
+false-positive results, please open a GitHub issue.
+
 ## Example project
 
 There is an example sbt project in the `example` folder so you can see the

--- a/src/main/scala-sbt-0.13/explicitdeps/package.scala
+++ b/src/main/scala-sbt-0.13/explicitdeps/package.scala
@@ -4,6 +4,15 @@ package object explicitdeps {
   type ModuleID = sbt.ModuleID
   type Binary = sbt.CrossVersion.Binary
   type Analysis = sbt.inc.Analysis
+  type ModuleFilter = sbt.ModuleFilter
+
+  val defaultModuleFilter: ModuleFilter = sbt.DependencyFilter.moduleFilter()
+
+  def toModuleID(dep: Dependency): ModuleID = sbt.ModuleID(
+    organization = dep.organization,
+    name = dep.name,
+    revision = dep.version
+  )
 
   def getAllLibraryDeps(analysis: Analysis): Set[java.io.File] =
     analysis.relations.allBinaryDeps.toSet

--- a/src/main/scala-sbt-1.0/explicitdeps/package.scala
+++ b/src/main/scala-sbt-1.0/explicitdeps/package.scala
@@ -4,6 +4,15 @@ package object explicitdeps {
   type ModuleID = sbt.librarymanagement.ModuleID
   type Binary = sbt.librarymanagement.Binary
   type Analysis = sbt.internal.inc.Analysis
+  type ModuleFilter = sbt.librarymanagement.ModuleFilter
+
+  val defaultModuleFilter: ModuleFilter = sbt.librarymanagement.DependencyFilter.moduleFilter()
+
+  def toModuleID(dep: Dependency): ModuleID = sbt.librarymanagement.ModuleID(
+    organization = dep.organization,
+    name = dep.name,
+    revision = dep.version
+  )
 
   def getAllLibraryDeps(analysis: Analysis): Set[java.io.File] =
     analysis.relations.allLibraryDeps.toSet

--- a/src/main/scala/explicitdeps/Logic.scala
+++ b/src/main/scala/explicitdeps/Logic.scala
@@ -9,12 +9,16 @@ object Logic {
     allLibraryDeps: Set[File],
     libraryDeps: Seq[ModuleID],
     scalaBinaryVer: String,
+    moduleFilter: ModuleFilter,
     log: Logger
   ): Set[Dependency] = {
     val compileDependencies = getCompileDependencies(allLibraryDeps, scalaBinaryVer, log)
     val declaredCompileDependencies = getDeclaredCompileDependencies(libraryDeps, scalaBinaryVer, log)
 
-    val undeclaredCompileDependencies = compileDependencies diff declaredCompileDependencies
+    val undeclaredCompileDependencies =
+      (compileDependencies diff declaredCompileDependencies)
+        .filter(dep => moduleFilter.apply(toModuleID(dep)))
+
     if (undeclaredCompileDependencies.nonEmpty) {
       val sorted = undeclaredCompileDependencies.toList.sortBy(dep => s"${dep.organization} ${dep.name}")
       log.warn(
@@ -32,12 +36,16 @@ object Logic {
     allLibraryDeps: Set[File],
     libraryDeps: Seq[ModuleID],
     scalaBinaryVer: String,
+    moduleFilter: ModuleFilter,
     log: Logger
   ): Set[Dependency] = {
     val compileDependencies = getCompileDependencies(allLibraryDeps, scalaBinaryVer, log)
     val declaredCompileDependencies = getDeclaredCompileDependencies(libraryDeps, scalaBinaryVer, log)
 
-    val unusedCompileDependencies = declaredCompileDependencies diff compileDependencies
+    val unusedCompileDependencies =
+      (declaredCompileDependencies diff compileDependencies)
+        .filter(dep => moduleFilter.apply(toModuleID(dep)))
+
     if (unusedCompileDependencies.nonEmpty) {
       val sorted = unusedCompileDependencies.toList.sortBy(dep => s"${dep.organization} ${dep.name}")
       log.warn(

--- a/src/sbt-test/basic/undeclared-dependency-filter/build.sbt
+++ b/src/sbt-test/basic/undeclared-dependency-filter/build.sbt
@@ -1,0 +1,5 @@
+scalaVersion := "2.12.6"
+libraryDependencies ++= Seq(
+  "org.typelevel" %% "cats-free" % "1.4.0"
+)
+undeclaredCompileDependenciesFilter -= moduleFilter(organization = "org.typelevel", name = "cats-core")

--- a/src/sbt-test/basic/undeclared-dependency-filter/project/plugins.sbt
+++ b/src/sbt-test/basic/undeclared-dependency-filter/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.github.cb372" % "sbt-explicit-dependencies" % sys.props("plugin.version"))

--- a/src/sbt-test/basic/undeclared-dependency-filter/src/main/scala/Main.scala
+++ b/src/sbt-test/basic/undeclared-dependency-filter/src/main/scala/Main.scala
@@ -1,0 +1,5 @@
+import cats.data.NonEmptyList
+
+object Main {
+  println(NonEmptyList.of(1, 2, 3))
+}

--- a/src/sbt-test/basic/undeclared-dependency-filter/test
+++ b/src/sbt-test/basic/undeclared-dependency-filter/test
@@ -1,0 +1,1 @@
+> undeclaredCompileDependenciesTest

--- a/src/sbt-test/basic/unused-dependency-filter/build.sbt
+++ b/src/sbt-test/basic/unused-dependency-filter/build.sbt
@@ -1,0 +1,6 @@
+scalaVersion := "2.12.6"
+libraryDependencies ++= Seq(
+  "org.typelevel" %% "cats-core" % "1.4.0",
+  "org.scalaz" %% "scalaz" % "7.2.26"
+)
+unusedCompileDependenciesFilter -= moduleFilter(organization = "org.scalaz", name = "scalaz")

--- a/src/sbt-test/basic/unused-dependency-filter/project/plugins.sbt
+++ b/src/sbt-test/basic/unused-dependency-filter/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.github.cb372" % "sbt-explicit-dependencies" % sys.props("plugin.version"))

--- a/src/sbt-test/basic/unused-dependency-filter/src/main/scala/Main.scala
+++ b/src/sbt-test/basic/unused-dependency-filter/src/main/scala/Main.scala
@@ -1,0 +1,5 @@
+import cats.data.NonEmptyList
+
+object Main {
+  println(NonEmptyList.of(1, 2, 3))
+}

--- a/src/sbt-test/basic/unused-dependency-filter/test
+++ b/src/sbt-test/basic/unused-dependency-filter/test
@@ -1,0 +1,1 @@
+> unusedCompileDependenciesTest


### PR DESCRIPTION
Adds two new settings `undeclaredCompileDependenciesFilter` and `unusedCompileDependenciesFilter` that can be used to exclude dependencies from the results of the `undeclaredCompileDependencies` and `unusedCompileDependencies` tasks respectively.

Fixes #13 