### PR TITLE
Dependencies with classifier show up as unused

### DIFF
--- a/src/main/scala/explicitdeps/BoringStuff.scala
+++ b/src/main/scala/explicitdeps/BoringStuff.scala
@@ -35,8 +35,9 @@ object BoringStuff {
 
   private def findIvyFileInIvyCache(jarFile: File): Option[File] = {
     // Ivy file should be in the parent directory, with the filename ivy-$version.xml
-    val potentialVersions = jarFile.getName.dropRight(4)
-      .split('-').tails.filter(_.nonEmpty).toList.map(_.mkString("-")).reverse
+    val artifactVersion = jarFile.getName.dropRight(4).split('-').tail
+    val potentialVersions = (artifactVersion.tails.toList.reverse ++ artifactVersion.inits.toList.tail)
+      .filter(_.nonEmpty).map(_.mkString("-"))
     val potentialIvyFiles = potentialVersions.map(version => new File(jarFile.getParentFile.getParentFile, s"ivy-$version.xml"))
     potentialIvyFiles.find(_.exists)
   }

--- a/src/sbt-test/basic/no-unused-no-undeclared-classifier/build.sbt
+++ b/src/sbt-test/basic/no-unused-no-undeclared-classifier/build.sbt
@@ -1,4 +1,4 @@
-scalaVersion := "2.12.6"
+scalaVersion := "2.12.8"
 libraryDependencies ++= Seq(
   "software.amazon.cryptools" % "AmazonCorrettoCryptoProvider" % "1.1.0" classifier "linux-x86_64"
 )

--- a/src/sbt-test/basic/no-unused-no-undeclared-classifier/build.sbt
+++ b/src/sbt-test/basic/no-unused-no-undeclared-classifier/build.sbt
@@ -1,0 +1,4 @@
+scalaVersion := "2.12.6"
+libraryDependencies ++= Seq(
+  "software.amazon.cryptools" % "AmazonCorrettoCryptoProvider" % "1.1.0" classifier "linux-x86_64"
+)

--- a/src/sbt-test/basic/no-unused-no-undeclared-classifier/project/plugins.sbt
+++ b/src/sbt-test/basic/no-unused-no-undeclared-classifier/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.github.cb372" % "sbt-explicit-dependencies" % sys.props("plugin.version"))

--- a/src/sbt-test/basic/no-unused-no-undeclared-classifier/src/main/scala/Main.scala
+++ b/src/sbt-test/basic/no-unused-no-undeclared-classifier/src/main/scala/Main.scala
@@ -1,0 +1,5 @@
+import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider
+
+object Main {
+  AmazonCorrettoCryptoProvider.install()
+}

--- a/src/sbt-test/basic/no-unused-no-undeclared-classifier/test
+++ b/src/sbt-test/basic/no-unused-no-undeclared-classifier/test
@@ -1,0 +1,2 @@
+> unusedCompileDependenciesTest
+> undeclaredCompileDependenciesTest

--- a/src/sbt-test/basic/no-unused-no-undeclared-provided/build.sbt
+++ b/src/sbt-test/basic/no-unused-no-undeclared-provided/build.sbt
@@ -1,4 +1,4 @@
-scalaVersion := "2.12.6"
+scalaVersion := "2.12.8"
 libraryDependencies ++= Seq(
   "org.typelevel" %% "cats-core" % "1.4.0" % Provided
 )


### PR DESCRIPTION
Fixes #34 

Given artifact-hyphenatedVersion (parts 1-k), this one searches `1 + 2(k-1) => 2k -1` possible versions instead of k.
Ex: Given `abc-f-g-h-k`, searches `k, h-k, g-h-k, f-g-h-k, f-g-h, f-g, f` as possible versions while the previous one searched `k, h-k, g-h-k, f-g-h-k, abc-f-g-h-k`