### PR TITLE
Allow optional declared dependencies

### DIFF
--- a/src/main/scala/explicitdeps/Logic.scala
+++ b/src/main/scala/explicitdeps/Logic.scala
@@ -96,7 +96,8 @@ object Logic {
     // - "test->compile", meaning the test config of this project depends on the compile config of the library
     // So a full config string could be "compile->compile; test->test".
     // We care whether the compile config of this project has a dependency on any config of the library.
-    moduleID.configurations.fold[Boolean](true)(conf => conf.split("; ?").exists(c => c.startsWith("compile") || c.startsWith("provided")))
+    moduleID.configurations.fold[Boolean](true)(conf => conf.split("; ?")
+      .exists(c => c.startsWith("compile") || c.startsWith("provided") || c.startsWith("optional")))
   }
 
 

--- a/src/sbt-test/basic/no-unused-no-undeclared-optional/build.sbt
+++ b/src/sbt-test/basic/no-unused-no-undeclared-optional/build.sbt
@@ -1,0 +1,4 @@
+scalaVersion := sys.props("scala.version")
+libraryDependencies ++= Seq(
+  "org.typelevel" %% "cats-core" % "1.4.0" % Optional
+)

--- a/src/sbt-test/basic/no-unused-no-undeclared-optional/project/plugins.sbt
+++ b/src/sbt-test/basic/no-unused-no-undeclared-optional/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.github.cb372" % "sbt-explicit-dependencies" % sys.props("plugin.version"))

--- a/src/sbt-test/basic/no-unused-no-undeclared-optional/src/main/scala/Main.scala
+++ b/src/sbt-test/basic/no-unused-no-undeclared-optional/src/main/scala/Main.scala
@@ -1,0 +1,5 @@
+import cats.data.NonEmptyList
+
+object Main {
+  println(NonEmptyList.of(1, 2, 3))
+}

--- a/src/sbt-test/basic/no-unused-no-undeclared-optional/test
+++ b/src/sbt-test/basic/no-unused-no-undeclared-optional/test
@@ -1,0 +1,2 @@
+> unusedCompileDependenciesTest
+> undeclaredCompileDependenciesTest


### PR DESCRIPTION
Optional dependencies were not picked up by this plugin, this PR adds that use-case and adds a testcase for this scenario. 

Closes #47