### PR TITLE
Correctly handle "Full" type of cross dependencies

### DIFF
--- a/src/main/scala-sbt-0.13/explicitdeps/package.scala
+++ b/src/main/scala-sbt-0.13/explicitdeps/package.scala
@@ -1,6 +1,7 @@
 package object explicitdeps {
 
   type Binary = sbt.CrossVersion.Binary
+  type Full = sbt.CrossVersion.Full
   type Analysis = sbt.inc.Analysis
   type ModuleFilter = sbt.ModuleFilter
 

--- a/src/main/scala-sbt-1.0/explicitdeps/package.scala
+++ b/src/main/scala-sbt-1.0/explicitdeps/package.scala
@@ -1,6 +1,7 @@
 package object explicitdeps {
 
   type Binary = sbt.librarymanagement.Binary
+  type Full = sbt.librarymanagement.Full
   type Analysis = sbt.internal.inc.Analysis
   type ModuleFilter = sbt.librarymanagement.ModuleFilter
 

--- a/src/main/scala/explicitdeps/ExplicitDepsPlugin.scala
+++ b/src/main/scala/explicitdeps/ExplicitDepsPlugin.scala
@@ -55,13 +55,14 @@ object ExplicitDepsPlugin extends AutoPlugin {
     val allLibraryDeps = getAllLibraryDeps(compile.in(Compile).value.asInstanceOf[Analysis], log)(csrCacheDirectoryValueOpt, baseDirectoryValue)
     val libraryDeps = libraryDependencies.value
     val scalaBinaryVer = scalaBinaryVersion.value
+    val scalaFullVer = scalaVersion.value
     val filter = undeclaredCompileDependenciesFilter.value
 
     Logic.getUndeclaredCompileDependencies(
       projectName,
       allLibraryDeps,
       libraryDeps,
-      scalaBinaryVer,
+      ScalaVersion(scalaBinaryVer, scalaFullVer),
       filter,
       log
     )
@@ -81,13 +82,14 @@ object ExplicitDepsPlugin extends AutoPlugin {
     val allLibraryDeps = getAllLibraryDeps(compile.in(Compile).value.asInstanceOf[Analysis], log)(csrCacheDirectoryValueOpt, baseDirectoryValue)
     val libraryDeps = libraryDependencies.value
     val scalaBinaryVer = scalaBinaryVersion.value
+    val scalaFullVer = scalaVersion.value
     val filter = unusedCompileDependenciesFilter.value
 
     Logic.getUnusedCompileDependencies(
       projectName,
       allLibraryDeps,
       libraryDeps,
-      scalaBinaryVer,
+      ScalaVersion(scalaBinaryVer, scalaFullVer),
       filter,
       log
     )

--- a/src/main/scala/explicitdeps/Logic.scala
+++ b/src/main/scala/explicitdeps/Logic.scala
@@ -4,7 +4,6 @@ import java.io.File
 
 import sbt.librarymanagement.ModuleID
 import sbt.util.Logger
-import sbt.librarymanagement.Full
 
 object Logic {
 

--- a/src/main/scala/explicitdeps/Logic.scala
+++ b/src/main/scala/explicitdeps/Logic.scala
@@ -4,6 +4,7 @@ import java.io.File
 
 import sbt.librarymanagement.ModuleID
 import sbt.util.Logger
+import sbt.librarymanagement.Full
 
 object Logic {
 
@@ -11,12 +12,12 @@ object Logic {
     projectName: String,
     allLibraryDeps: Set[File],
     libraryDeps: Seq[ModuleID],
-    scalaBinaryVer: String,
+    scalaVersion: ScalaVersion,
     moduleFilter: ModuleFilter,
     log: Logger
   ): Set[Dependency] = {
-    val compileDependencies = getCompileDependencies(allLibraryDeps, scalaBinaryVer, log)
-    val declaredCompileDependencies = getDeclaredCompileDependencies(libraryDeps, scalaBinaryVer, log)
+    val compileDependencies = getCompileDependencies(allLibraryDeps, scalaVersion, log)
+    val declaredCompileDependencies = getDeclaredCompileDependencies(libraryDeps, scalaVersion, log)
 
     val undeclaredCompileDependencies =
       (compileDependencies diff declaredCompileDependencies)
@@ -38,12 +39,12 @@ object Logic {
     projectName: String,
     allLibraryDeps: Set[File],
     libraryDeps: Seq[ModuleID],
-    scalaBinaryVer: String,
+    scalaVersion: ScalaVersion,
     moduleFilter: ModuleFilter,
     log: Logger
   ): Set[Dependency] = {
-    val compileDependencies = getCompileDependencies(allLibraryDeps, scalaBinaryVer, log)
-    val declaredCompileDependencies = getDeclaredCompileDependencies(libraryDeps, scalaBinaryVer, log)
+    val compileDependencies = getCompileDependencies(allLibraryDeps, scalaVersion, log)
+    val declaredCompileDependencies = getDeclaredCompileDependencies(libraryDeps, scalaVersion, log)
 
     val unusedCompileDependencies =
       (declaredCompileDependencies diff compileDependencies)
@@ -61,7 +62,7 @@ object Logic {
     unusedCompileDependencies
   }
 
-  private def getCompileDependencies(allLibraryDeps: Set[File], scalaBinaryVersion: String, log: Logger): Set[Dependency] = {
+  private def getCompileDependencies(allLibraryDeps: Set[File], scalaVersion: ScalaVersion, log: Logger): Set[Dependency] = {
     val compileDependencyJarFiles =
       allLibraryDeps
         .filter(_.getName.endsWith(".jar"))
@@ -69,19 +70,22 @@ object Logic {
         .filterNot(_.getName matches "scala-library.*\\.jar")
 
     val compileDependencies = compileDependencyJarFiles
-      .flatMap(BoringStuff.jarFileToDependency(scalaBinaryVersion, log))
+      .flatMap(BoringStuff.jarFileToDependency(scalaVersion, log))
     log.debug(s"Compile depends on:\n${compileDependencies.mkString("  ", "\n  ", "")}")
 
     compileDependencies
   }
 
-  private def getDeclaredCompileDependencies(libraryDependencies: Seq[ModuleID], scalaBinaryVersion: String, log: Logger): Set[Dependency] = {
+  private def getDeclaredCompileDependencies(libraryDependencies: Seq[ModuleID], scalaVersion: ScalaVersion, log: Logger): Set[Dependency] = {
     val compileConfigLibraryDependencies = libraryDependencies
       .filter(isCompileDependency)
       .filterNot(_.name == "scala-library")
 
     val declaredCompileDependencies = compileConfigLibraryDependencies
-      .map(moduleId => Dependency(moduleId.organization, moduleId.name, moduleId.revision, moduleId.crossVersion.isInstanceOf[Binary]))
+      .map{moduleId => 
+        val isCross = moduleId.crossVersion.isInstanceOf[Binary] ||  moduleId.crossVersion.isInstanceOf[Full]
+        Dependency(moduleId.organization, moduleId.name, moduleId.revision, isCross)
+      }
     log.debug(s"Declared dependencies:\n${declaredCompileDependencies.mkString("  ", "\n  ", "")}")
 
     declaredCompileDependencies.toSet

--- a/src/sbt-test/basic/full-scala-version/build.sbt
+++ b/src/sbt-test/basic/full-scala-version/build.sbt
@@ -1,0 +1,4 @@
+scalaVersion := sys.props("scala.version")
+libraryDependencies ++= Seq(
+  "com.lihaoyi" %% "ammonite-interp-api" % "2.2.0-4-4bd225e" cross(CrossVersion.full)
+)

--- a/src/sbt-test/basic/full-scala-version/project/build.properties
+++ b/src/sbt-test/basic/full-scala-version/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.4.3

--- a/src/sbt-test/basic/full-scala-version/project/build.properties
+++ b/src/sbt-test/basic/full-scala-version/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.4.3

--- a/src/sbt-test/basic/full-scala-version/project/plugins.sbt
+++ b/src/sbt-test/basic/full-scala-version/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.github.cb372" % "sbt-explicit-dependencies" % sys.props("plugin.version"))

--- a/src/sbt-test/basic/full-scala-version/src/main/scala/Main.scala
+++ b/src/sbt-test/basic/full-scala-version/src/main/scala/Main.scala
@@ -1,0 +1,5 @@
+import ammonite.interp.api.IvyConstructor
+
+object Main {
+  println(IvyConstructor.scalaBinaryVersion)
+}

--- a/src/sbt-test/basic/full-scala-version/test
+++ b/src/sbt-test/basic/full-scala-version/test
@@ -1,0 +1,2 @@
+> unusedCompileDependenciesTest
+> undeclaredCompileDependenciesTest


### PR DESCRIPTION
Adding a dependency with `Full` cross type breaks:

```scala
libraryDependencies ++= Seq(
  "com.lihaoyi" %% "ammonite-interp-api" % "2.2.0-4-4bd225e" cross(CrossVersion.full)
)
```

```
[error] (undeclaredCompileDependenciesTest) Failing the build because undeclared dependencies were found
[error] Total time: 0 s, completed 26-Nov-2020 17:26:24
sbt:full-scala-version> undeclaredCompileDependenciesTest
[warn] full-scala-version >>> The project depends on the following libraries for compilation but they are not declared in libraryDependencies:
[warn]  - "com.lihaoyi" % "ammonite-interp-api_2.13.3" % "2.3.7"
```

I've reproduced the issue in a new scripted test and provided a possible fix (hoping CI can show nice improvement). 

@cb372 let me know what you think :)

_Note: sorry for thrashing about, turns out I have 1.x tunnel vision when it comes to SBT versions_