### PR TITLE
Fix locating artifacts published locally

### DIFF
--- a/src/main/scala-sbt-0.13/explicitdeps/package.scala
+++ b/src/main/scala-sbt-0.13/explicitdeps/package.scala
@@ -8,7 +8,8 @@ package object explicitdeps {
   val defaultModuleFilter: ModuleFilter = sbt.DependencyFilter.moduleFilter()
 
   // csrCacheDirectoryValueOpt, baseDirectoryValue are unused and are only present for forward compatibility
-  def getAllLibraryDeps(analysis: Analysis, log: sbt.util.Logger)(csrCacheDirectoryValueOpt: Option[String], baseDirectoryValue: String): Set[java.io.File] = {
+  def getAllLibraryDeps(analysis: Analysis, log: sbt.util.Logger)
+    (csrCacheDirectoryValueOpt: Option[String], baseDirectoryValue: String, ivyHomeValue: String): Set[java.io.File] = {
     log.debug(
       s"Source to library relations:\n${analysis.relations.binaryDep.all.map(r => s"  ${r._1} -> ${r._2}").mkString("\n")}"
     )

--- a/src/main/scala/explicitdeps/ExplicitDepsPlugin.scala
+++ b/src/main/scala/explicitdeps/ExplicitDepsPlugin.scala
@@ -52,7 +52,8 @@ object ExplicitDepsPlugin extends AutoPlugin {
     val projectName = name.value
     val csrCacheDirectoryValueOpt = csrCacheDirectoryValueTask.value
     val baseDirectoryValue = appConfiguration.value.baseDirectory().getCanonicalFile.toPath.toString
-    val allLibraryDeps = getAllLibraryDeps(compile.in(Compile).value.asInstanceOf[Analysis], log)(csrCacheDirectoryValueOpt, baseDirectoryValue)
+    val ivyHomeValue = appConfiguration.value.provider.scalaProvider.launcher.ivyHome.toString
+    val allLibraryDeps = getAllLibraryDeps(compile.in(Compile).value.asInstanceOf[Analysis], log)(csrCacheDirectoryValueOpt, baseDirectoryValue, ivyHomeValue)
     val libraryDeps = libraryDependencies.value
     val scalaBinaryVer = scalaBinaryVersion.value
     val scalaFullVer = scalaVersion.value
@@ -79,7 +80,8 @@ object ExplicitDepsPlugin extends AutoPlugin {
     val projectName = name.value
     val csrCacheDirectoryValueOpt = csrCacheDirectoryValueTask.value
     val baseDirectoryValue = appConfiguration.value.baseDirectory().getCanonicalFile.toPath.toString
-    val allLibraryDeps = getAllLibraryDeps(compile.in(Compile).value.asInstanceOf[Analysis], log)(csrCacheDirectoryValueOpt, baseDirectoryValue)
+    val ivyHomeValue = appConfiguration.value.provider.scalaProvider.launcher.ivyHome.toString
+    val allLibraryDeps = getAllLibraryDeps(compile.in(Compile).value.asInstanceOf[Analysis], log)(csrCacheDirectoryValueOpt, baseDirectoryValue, ivyHomeValue)
     val libraryDeps = libraryDependencies.value
     val scalaBinaryVer = scalaBinaryVersion.value
     val scalaFullVer = scalaVersion.value


### PR DESCRIPTION
When using `sbt-explicit-dependencies` with SBT 1.4+, if the build depends
on a local artifact (e.g. published locally with `sbt publishLocal`), then
the task reports dependency as unused.
Substituting `${IVY_HOME}` fixes this behaviour.