### PR TITLE
Make plugin depend on IvyPlugin

### DIFF
--- a/example/project/plugins.sbt
+++ b/example/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.github.cb372" % "sbt-explicit-dependencies" % "v0.3.1")
+addSbtPlugin("com.github.cb372" % "sbt-explicit-dependencies" % "0.3.1")

--- a/src/main/scala/explicitdeps/ExplicitDepsPlugin.scala
+++ b/src/main/scala/explicitdeps/ExplicitDepsPlugin.scala
@@ -24,7 +24,7 @@ object ExplicitDepsPlugin extends AutoPlugin {
   import autoImport._
 
   override def trigger = allRequirements
-  override def requires = empty
+  override def requires = sbt.plugins.IvyPlugin
   override lazy val projectSettings = Seq(
     undeclaredCompileDependencies := undeclaredCompileDependenciesTask.value,
     undeclaredCompileDependenciesTest := undeclaredCompileDependenciesTestTask.value,


### PR DESCRIPTION
Currently the plugin is triggered for all sbt projects regardless. Even for those with `disablePlugins(sbt.plugins.JvmPlugin, sbt.plugins.IvyPlugin)`, which fails with:
```
References to undefined settings: 

  pulumi / Compile / compile from pulumi / undeclaredCompileDependencies ((explicitdeps.ExplicitDepsPlugin.projectSettings) ExplicitDepsPlugin.scala:29)

  pulumi / Compile / compile from pulumi / unusedCompileDependencies ((explicitdeps.ExplicitDepsPlugin.projectSettings) ExplicitDepsPlugin.scala:33)
```

This also includes a fix for this problem:
```
[info] Resolved  dependencies
[warn] 
[warn] 	Note: Some unresolved dependencies have extra attributes.  Check that these dependencies exist with the requested attributes.
[warn] 		com.github.cb372:sbt-explicit-dependencies:v0.3.1 (sbtVersion=1.0, scalaVersion=2.12)
[warn] 
```