### PR TITLE
Handle semver metadata in version string

### DIFF
--- a/src/main/scala/explicitdeps/BoringStuff.scala
+++ b/src/main/scala/explicitdeps/BoringStuff.scala
@@ -65,7 +65,12 @@ object BoringStuff {
       val rawName = (xml \ "artifactId").text
 
       // We use the parent dir to get the version because it's sometimes not present in the pom file
-      val version = file.getParentFile.getName
+      // We use URL decoder to cater for characters that are valid in version strings but encoded
+      // in the file path, such as "+" used for semver metadata, encoded as "%2B"
+      val version = java.net.URLDecoder.decode(
+        file.getParentFile.getName,
+        java.nio.charset.Charset.forName("utf8")
+      )
 
       val (name, crossVersion) = parseModuleName(scalaVersion)(rawName)
 

--- a/src/sbt-test/basic/semver-metadata/build.sbt
+++ b/src/sbt-test/basic/semver-metadata/build.sbt
@@ -1,0 +1,5 @@
+scalaVersion := sys.props("scala.version")
+resolvers ++= Seq("Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots")
+libraryDependencies ++= Seq(
+  "org.scalaz" %% "scalaz-core" % "7.2.27+33-04a1ea9e-SNAPSHOT"
+)

--- a/src/sbt-test/basic/semver-metadata/project/plugins.sbt
+++ b/src/sbt-test/basic/semver-metadata/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.github.cb372" % "sbt-explicit-dependencies" % sys.props("plugin.version"))

--- a/src/sbt-test/basic/semver-metadata/src/main/scala/Main.scala
+++ b/src/sbt-test/basic/semver-metadata/src/main/scala/Main.scala
@@ -1,0 +1,10 @@
+import scalaz._
+import scalaz.std.anyVal._
+import scalaz.std.list._
+import scalaz.std.option._
+import scalaz.syntax.equal._ 
+
+object Main {
+  val list1: List[Option[Int]] = List(Some(1), Some(2), Some(3), Some(4))
+  assert(Traverse[List].sequence(list1) === Some(List(1,2,3,4)))
+}

--- a/src/sbt-test/basic/semver-metadata/test
+++ b/src/sbt-test/basic/semver-metadata/test
@@ -1,0 +1,2 @@
+> unusedCompileDependenciesTest
+> undeclaredCompileDependenciesTest


### PR DESCRIPTION
## What

Update how version is parsed for pom files in the 'jar file to dependency' logic to cater for characters that are valid
in version strings but encoded in the file path.

For example, `"+"` encoded as `"%2B"`.

The character is commonly used in semver version strings to add build metadata to the version. Per https://semver.org/

## Why

Before this change `7.2.27+33-04a1ea9e-SNAPSHOT` version string was not handled consistently and would result in different values in the declared/used compile dependencies. This meant that the plugin was not usable for dependencies with build metadata in their version string.

Fixes: https://github.com/cb372/sbt-explicit-dependencies/issues/110