### PR TITLE
Add unusedCompileDependenciesAggregate

### DIFF
--- a/src/main/scala/explicitdeps/ExplicitDepsPlugin.scala
+++ b/src/main/scala/explicitdeps/ExplicitDepsPlugin.scala
@@ -84,10 +84,16 @@ object ExplicitDepsPlugin extends AutoPlugin {
 
     log.debug(s"Aggregated ${mergedUsedDeps.size} unique used jars and ${mergedDeclaredDeps.size} unique declared modules across all projects.")
     log.debug("Aggregated Used Dependencies:")
-    mergedUsedDeps.foreach(dep => log.debug(s"  - ${dep.getName}"))
+    mergedUsedDeps.toSeq.sorted.foreach(dep => log.debug(s"  - ${dep.getName}"))
 
     log.debug("Aggregated Declared Dependencies:")
-    mergedDeclaredDeps.foreach(dep => log.debug(s"  - ${dep.organization} % ${dep.name} % ${dep.revision}"))
+    val namePadding = mergedDeclaredDeps.map(_.name.length).max + 3
+    mergedDeclaredDeps
+      .toSeq.sorted(Ordering.by[ModuleID, String](_.name))
+      .foreach { dep =>
+        val paddedName = dep.name.padTo(namePadding, ' ')
+        log.debug(s"  - $paddedName${dep.organization} % ${dep.name} % ${dep.revision}")
+      }
     (mergedUsedDeps, mergedDeclaredDeps.toSeq)
   }
 

--- a/src/main/scala/explicitdeps/ExplicitDepsPlugin.scala
+++ b/src/main/scala/explicitdeps/ExplicitDepsPlugin.scala
@@ -57,34 +57,39 @@ object ExplicitDepsPlugin extends AutoPlugin {
   private lazy val collectLibraryDepsProjectTask = Def.task {
     val log = streams.value.log
 
-    val analysis = (Compile / compile).value.asInstanceOf[Analysis]
+    val compileAnalysis = (Compile / compile).value.asInstanceOf[Analysis]
+    val testAnalysis = (Test / compile).value.asInstanceOf[Analysis]
 
     val csrCacheDirectoryOpt = csrCacheDirectory.?.value.map(_.getAbsolutePath)
     val baseDir = baseDirectory.value.getAbsolutePath
 
-    val usedDeps: Set[File] = getAllLibraryDeps(analysis, log)(csrCacheDirectoryOpt, baseDir)
+    val usedCompileDeps: Set[File] = getAllLibraryDeps(compileAnalysis, log)(csrCacheDirectoryOpt, baseDir)
+    val usedTestDeps: Set[File] = getAllLibraryDeps(testAnalysis, log)(csrCacheDirectoryOpt, baseDir)
     val declaredDeps: Seq[ModuleID] = libraryDependencies.value
 
-    log.debug(s"[${name.value}] Found ${usedDeps.size} used jars and ${declaredDeps.size} declared modules.")
+    log.debug(s"[${name.value}] Found ${(usedCompileDeps ++ usedTestDeps).size} used jars and ${declaredDeps.size} declared modules.")
 
-    (usedDeps, declaredDeps)
+    (usedCompileDeps, usedTestDeps, declaredDeps)
   }
 
   private lazy val collectLibraryDepsAllTask = Def.task {
     val log = streams.value.log
 
-    val projectResults: Seq[(Set[File], Seq[ModuleID])] = collectLibraryDepsProjectTask.all(
-      ScopeFilter(inAnyProject, inConfigurations(Compile))
+    val projectResults: Seq[(Set[File], Set[File], Seq[ModuleID])] = collectLibraryDepsProjectTask.all(
+      ScopeFilter(inAnyProject, inAnyConfiguration)
     ).value
 
-    val (allUsedDeps, allDeclaredDeps) = projectResults.unzip
+    val (allUsedCompileDeps, allUsedTestDeps, allDeclaredDeps) = projectResults.unzip3
 
-    val mergedUsedDeps = allUsedDeps.flatten.toSet
+    val mergedUsedCompileDeps = allUsedCompileDeps.flatten.toSet
+    val mergedUsedTestDeps = allUsedTestDeps.flatten.toSet
     val mergedDeclaredDeps = allDeclaredDeps.flatten.toSet
 
-    log.debug(s"Aggregated ${mergedUsedDeps.size} unique used jars and ${mergedDeclaredDeps.size} unique declared modules across all projects.")
-    log.debug("Aggregated Used Dependencies:")
-    mergedUsedDeps.toSeq.sorted.foreach(dep => log.debug(s"  - ${dep.getName}"))
+    log.debug(s"Aggregated ${(mergedUsedCompileDeps ++ mergedUsedTestDeps).size} unique used jars and ${mergedDeclaredDeps.size} unique declared modules across all projects.")
+    log.debug("Aggregated Used Compile Dependencies:")
+    mergedUsedCompileDeps.toSeq.sorted.foreach(dep => log.debug(s"  - ${dep.getName}"))
+    log.debug("Aggregated Used Test Dependencies:")
+    mergedUsedTestDeps.toSeq.sorted.foreach(dep => log.debug(s"  - ${dep.getName}"))
 
     log.debug("Aggregated Declared Dependencies:")
     val namePadding = mergedDeclaredDeps.map(_.name.length).max + 3
@@ -94,7 +99,7 @@ object ExplicitDepsPlugin extends AutoPlugin {
         val paddedName = dep.name.padTo(namePadding, ' ')
         log.debug(s"  - $paddedName${dep.organization} % ${dep.name} % ${dep.revision}")
       }
-    (mergedUsedDeps, mergedDeclaredDeps.toSeq)
+    (mergedUsedCompileDeps, mergedUsedTestDeps, mergedDeclaredDeps.toSeq)
   }
 
   lazy val undeclaredCompileDependenciesTask = Def.task {
@@ -130,6 +135,7 @@ object ExplicitDepsPlugin extends AutoPlugin {
     val csrCacheDirectoryValueOpt = csrCacheDirectoryValueTask.value
     val baseDirectoryValue = appConfiguration.value.baseDirectory().getCanonicalFile.toPath.toString
     val allLibraryDeps = getAllLibraryDeps((Compile / compile).value.asInstanceOf[Analysis], log)(csrCacheDirectoryValueOpt, baseDirectoryValue)
+    val allLibraryTestDeps = getAllLibraryDeps((Test / compile).value.asInstanceOf[Analysis], log)(csrCacheDirectoryValueOpt, baseDirectoryValue)
     val libraryDeps = libraryDependencies.value
     val scalaBinaryVer = scalaBinaryVersion.value
     val scalaFullVer = scalaVersion.value
@@ -138,6 +144,7 @@ object ExplicitDepsPlugin extends AutoPlugin {
     Logic.getUnusedCompileDependencies(
       projectName,
       allLibraryDeps,
+      allLibraryTestDeps,
       libraryDeps,
       ScalaVersion(scalaBinaryVer, scalaFullVer),
       filter,
@@ -154,14 +161,15 @@ object ExplicitDepsPlugin extends AutoPlugin {
   lazy val unusedCompileDependenciesAggregateTask = Def.task {
     val log = streams.value.log
     val projectName = name.value
-    val (usedDeps, declaredDeps) = collectLibraryDepsAllTask.value
+    val (usedCompileDeps, usedTestDeps, declaredDeps) = collectLibraryDepsAllTask.value
     val scalaBinaryVer = scalaBinaryVersion.value
     val scalaFullVer = scalaVersion.value
     val filter = unusedCompileDependenciesFilter.value
 
     Logic.getUnusedCompileDependencies(
       projectName,
-      usedDeps,
+      usedCompileDeps,
+      usedTestDeps,
       declaredDeps,
       ScalaVersion(scalaBinaryVer, scalaFullVer),
       filter,

--- a/src/main/scala/explicitdeps/ExplicitDepsPlugin.scala
+++ b/src/main/scala/explicitdeps/ExplicitDepsPlugin.scala
@@ -96,7 +96,7 @@ object ExplicitDepsPlugin extends AutoPlugin {
     val projectName = name.value
     val csrCacheDirectoryValueOpt = csrCacheDirectoryValueTask.value
     val baseDirectoryValue = appConfiguration.value.baseDirectory().getCanonicalFile.toPath.toString
-    val allLibraryDeps = getAllLibraryDeps(compile.in(Compile).value.asInstanceOf[Analysis], log)(csrCacheDirectoryValueOpt, baseDirectoryValue)
+    val allLibraryDeps = getAllLibraryDeps((Compile / compile).value.asInstanceOf[Analysis], log)(csrCacheDirectoryValueOpt, baseDirectoryValue)
     val libraryDeps = libraryDependencies.value
     val scalaBinaryVer = scalaBinaryVersion.value
     val scalaFullVer = scalaVersion.value
@@ -123,7 +123,7 @@ object ExplicitDepsPlugin extends AutoPlugin {
     val projectName = name.value
     val csrCacheDirectoryValueOpt = csrCacheDirectoryValueTask.value
     val baseDirectoryValue = appConfiguration.value.baseDirectory().getCanonicalFile.toPath.toString
-    val allLibraryDeps = getAllLibraryDeps(compile.in(Compile).value.asInstanceOf[Analysis], log)(csrCacheDirectoryValueOpt, baseDirectoryValue)
+    val allLibraryDeps = getAllLibraryDeps((Compile / compile).value.asInstanceOf[Analysis], log)(csrCacheDirectoryValueOpt, baseDirectoryValue)
     val libraryDeps = libraryDependencies.value
     val scalaBinaryVer = scalaBinaryVersion.value
     val scalaFullVer = scalaVersion.value

--- a/src/main/scala/explicitdeps/ExplicitDepsPlugin.scala
+++ b/src/main/scala/explicitdeps/ExplicitDepsPlugin.scala
@@ -18,7 +18,9 @@ object ExplicitDepsPlugin extends AutoPlugin {
     val undeclaredCompileDependenciesFilter = settingKey[ModuleFilter]("Filter to specify the undeclared dependencies that you care about")
 
     val unusedCompileDependencies = taskKey[Set[Dependency]]("find all libraries declared in libraryDependencies that this project's code does not actually depend on for compilation")
+    val unusedCompileDependenciesAggregate = taskKey[Set[Dependency]]("find all libraries declared in libraryDependencies that this project's code does not actually depend on for compilation, aggregated for all subprojects")
     val unusedCompileDependenciesTest = taskKey[Unit]("fail the build if there are any libraries declared in libraryDependencies that this project's code does not actually depend on for compilation")
+    val unusedCompileDependenciesAggregateTest = taskKey[Unit]("fail the build if there are any libraries declared in libraryDependencies that this project's code does not actually depend on for compilation, aggregated for all subprojects")
     val unusedCompileDependenciesFilter = settingKey[ModuleFilter]("Filter to specify the undeclared dependencies that you care about")
   }
   import autoImport._
@@ -31,8 +33,13 @@ object ExplicitDepsPlugin extends AutoPlugin {
     undeclaredCompileDependenciesFilter := defaultModuleFilter,
 
     unusedCompileDependencies := unusedCompileDependenciesTask.value,
+    unusedCompileDependenciesAggregate := unusedCompileDependenciesAggregateTask.value,
     unusedCompileDependenciesTest := unusedCompileDependenciesTestTask.value,
-    unusedCompileDependenciesFilter := defaultModuleFilter
+    unusedCompileDependenciesAggregateTest := unusedCompileDependenciesAggregateTestTask.value,
+    unusedCompileDependenciesFilter := defaultModuleFilter,
+
+    unusedCompileDependenciesAggregate / aggregate := false,
+    unusedCompileDependenciesAggregateTest / aggregate := false
   )
 
   // Evaluate "csrCacheDirectory" setting which is present only in sbt 1.3.0 or newer
@@ -45,6 +52,43 @@ object ExplicitDepsPlugin extends AutoPlugin {
         Some(csrCacheDirectoryValue)
       case _ => None
     }
+  }
+
+  private lazy val collectLibraryDepsProjectTask = Def.task {
+    val log = streams.value.log
+
+    val analysis = (Compile / compile).value.asInstanceOf[Analysis]
+
+    val csrCacheDirectoryOpt = csrCacheDirectory.?.value.map(_.getAbsolutePath)
+    val baseDir = baseDirectory.value.getAbsolutePath
+
+    val usedDeps: Set[File] = getAllLibraryDeps(analysis, log)(csrCacheDirectoryOpt, baseDir)
+    val declaredDeps: Seq[ModuleID] = libraryDependencies.value
+
+    log.debug(s"[${name.value}] Found ${usedDeps.size} used jars and ${declaredDeps.size} declared modules.")
+
+    (usedDeps, declaredDeps)
+  }
+
+  private lazy val collectLibraryDepsAllTask = Def.task {
+    val log = streams.value.log
+
+    val projectResults: Seq[(Set[File], Seq[ModuleID])] = collectLibraryDepsProjectTask.all(
+      ScopeFilter(inAnyProject, inConfigurations(Compile))
+    ).value
+
+    val (allUsedDeps, allDeclaredDeps) = projectResults.unzip
+
+    val mergedUsedDeps = allUsedDeps.flatten.toSet
+    val mergedDeclaredDeps = allDeclaredDeps.flatten.toSet
+
+    log.debug(s"Aggregated ${mergedUsedDeps.size} unique used jars and ${mergedDeclaredDeps.size} unique declared modules across all projects.")
+    log.debug("Aggregated Used Dependencies:")
+    mergedUsedDeps.foreach(dep => log.debug(s"  - ${dep.getName}"))
+
+    log.debug("Aggregated Declared Dependencies:")
+    mergedDeclaredDeps.foreach(dep => log.debug(s"  - ${dep.organization} % ${dep.name} % ${dep.revision}"))
+    (mergedUsedDeps, mergedDeclaredDeps.toSeq)
   }
 
   lazy val undeclaredCompileDependenciesTask = Def.task {
@@ -101,4 +145,27 @@ object ExplicitDepsPlugin extends AutoPlugin {
       throw UnusedCompileDependenciesException
   }
 
+  lazy val unusedCompileDependenciesAggregateTask = Def.task {
+    val log = streams.value.log
+    val projectName = name.value
+    val (usedDeps, declaredDeps) = collectLibraryDepsAllTask.value
+    val scalaBinaryVer = scalaBinaryVersion.value
+    val scalaFullVer = scalaVersion.value
+    val filter = unusedCompileDependenciesFilter.value
+
+    Logic.getUnusedCompileDependencies(
+      projectName,
+      usedDeps,
+      declaredDeps,
+      ScalaVersion(scalaBinaryVer, scalaFullVer),
+      filter,
+      log
+    )
+  }
+
+  lazy val unusedCompileDependenciesAggregateTestTask = Def.task {
+    val unusedCompileDeps = unusedCompileDependenciesAggregate.value
+    if (unusedCompileDeps.nonEmpty)
+      throw UnusedCompileDependenciesException
+  }
 }

--- a/src/main/scala/explicitdeps/Logic.scala
+++ b/src/main/scala/explicitdeps/Logic.scala
@@ -16,7 +16,7 @@ object Logic {
     log: Logger
   ): Set[Dependency] = {
     val compileDependencies = getCompileDependencies(allLibraryDeps, scalaVersion, log)
-    val declaredCompileDependencies = getDeclaredCompileDependencies(libraryDeps, scalaVersion, log)
+    val (declaredCompileDependencies, _) = getDeclaredCompileDependencies(libraryDeps, scalaVersion, log)
 
     val undeclaredCompileDependencies =
       (compileDependencies diff declaredCompileDependencies)
@@ -36,29 +36,58 @@ object Logic {
 
   def getUnusedCompileDependencies(
     projectName: String,
-    allLibraryDeps: Set[File],
+    allLibraryCompileDeps: Set[File],
+    allLibraryTestDeps: Set[File],
     libraryDeps: Seq[ModuleID],
     scalaVersion: ScalaVersion,
     moduleFilter: ModuleFilter,
     log: Logger
   ): Set[Dependency] = {
-    val compileDependencies = getCompileDependencies(allLibraryDeps, scalaVersion, log)
-    val declaredCompileDependencies = getDeclaredCompileDependencies(libraryDeps, scalaVersion, log)
+    val compileDependencies = {
+      log.debug("Checking Compile Dependencies")
+      getCompileDependencies(allLibraryCompileDeps, scalaVersion, log)
+    }
+    val compileTestDependencies = {
+      log.debug("Checking Test Compile Dependencies")
+      getCompileDependencies(allLibraryTestDeps, scalaVersion, log)
+    }
+    val (declaredCompileDependencies, declaredTestDependencies) = getDeclaredCompileDependencies(libraryDeps, scalaVersion, log)
 
     val unusedCompileDependencies =
       (declaredCompileDependencies diff compileDependencies)
         .filter(dep => moduleFilter.apply(toModuleID(dep)))
+
+    val unusedTestDependencies =
+      (declaredTestDependencies diff compileTestDependencies)
+        .filter(dep => moduleFilter.apply(toModuleID(dep)))
+
+    val wrongCategoryDependencies =
+      (unusedTestDependencies intersect compileDependencies) ++ (unusedCompileDependencies intersect compileTestDependencies)
 
     if (unusedCompileDependencies.nonEmpty) {
       val sorted = unusedCompileDependencies.toList.sortBy(dep => s"${dep.organization} ${dep.name}")
       log.warn(
         s"""$projectName >>> The following libraries are declared in libraryDependencies but are not needed for compilation:
            | - ${sorted.mkString("\n - ")}""".stripMargin)
-    } else {
+    }
+    if (unusedTestDependencies.nonEmpty) {
+      val sorted = unusedTestDependencies.toList.sortBy(dep => s"${dep.organization} ${dep.name}")
+      log.warn(
+        s"""$projectName >>> The following libraries are declared in libraryDependencies as '% Test' but are not needed for test compilation:
+           | - ${sorted.mkString("\n - ")}""".stripMargin)
+    }
+    if (wrongCategoryDependencies.nonEmpty) {
+      val sorted = wrongCategoryDependencies.toList.sortBy(dep => s"${dep.organization} ${dep.name}")
+      log.warn(
+        s"""$projectName >>> The following libraries are declared in libraryDependencies in the wrong category (test/nontest):
+           | - ${sorted.mkString("\n - ")}""".stripMargin)
+    }
+    if (unusedCompileDependencies.isEmpty && unusedTestDependencies.isEmpty && wrongCategoryDependencies.isEmpty)
+    {
       log.info(s"$projectName >>> The project has no unused dependencies declared in libraryDependencies. Good job!")
     }
 
-    unusedCompileDependencies
+    unusedCompileDependencies ++ unusedTestDependencies
   }
 
   private def getCompileDependencies(allLibraryDeps: Set[File], scalaVersion: ScalaVersion, log: Logger): Set[Dependency] = {
@@ -79,22 +108,32 @@ object Logic {
     compileDependencies
   }
 
-  private def getDeclaredCompileDependencies(libraryDependencies: Seq[ModuleID], scalaVersion: ScalaVersion, log: Logger): Set[Dependency] = {
-    val compileConfigLibraryDependencies = libraryDependencies
-      .filter(isCompileDependency)
-      .filterNot(_.name == "scala-library")
-      .filterNot(_.name == "scalajs-library")
-      .filterNot(_.name == "scala3-library")
+  private def getDeclaredCompileDependencies(
+    libraryDependencies: Seq[ModuleID],
+    scalaVersion: ScalaVersion,
+    log: Logger
+  ): (Set[Dependency], Set[Dependency]) = {
+    def filterScalaLibsAndMapDependency(libraryDependencies: Seq[ModuleID]): Seq[Dependency] = {
+      val compileConfigLibraryDependencies = libraryDependencies
+        .filterNot(_.name == "scala-library")
+        .filterNot(_.name == "scalajs-library")
+        .filterNot(_.name == "scala3-library")
 
+      val declaredCompileDependencies = compileConfigLibraryDependencies
+        .map{moduleId =>
+          val isCross = moduleId.crossVersion.isInstanceOf[Binary] ||  moduleId.crossVersion.isInstanceOf[Full]
+          Dependency(moduleId.organization, moduleId.name, moduleId.revision, isCross)
+        }
+      declaredCompileDependencies
+    }
 
-    val declaredCompileDependencies = compileConfigLibraryDependencies
-      .map{moduleId => 
-        val isCross = moduleId.crossVersion.isInstanceOf[Binary] ||  moduleId.crossVersion.isInstanceOf[Full]
-        Dependency(moduleId.organization, moduleId.name, moduleId.revision, isCross)
-      }
-    log.debug(s"Declared dependencies:\n${declaredCompileDependencies.mkString("  ", "\n  ", "")}")
+    val declaredCompileDependencies = filterScalaLibsAndMapDependency(libraryDependencies.filter(isCompileDependency))
+    val declaredTestDependencies = filterScalaLibsAndMapDependency(libraryDependencies.filter(isTestDependency))
 
-    declaredCompileDependencies.toSet
+    log.debug(s"Declared Compile dependencies:\n${declaredCompileDependencies.mkString("  ", "\n  ", "")}")
+    log.debug(s"Declared Test dependencies:\n${declaredTestDependencies.mkString("  ", "\n  ", "")}")
+
+    (declaredCompileDependencies.toSet, declaredTestDependencies.toSet)
   }
 
   private def isCompileDependency(moduleID: ModuleID): Boolean = {
@@ -110,6 +149,9 @@ object Logic {
       .exists(c => c.startsWith("compile") || c.startsWith("provided") || c.startsWith("optional")))
   }
 
+  private def isTestDependency(moduleID: ModuleID): Boolean = {
+    moduleID.configurations.exists(conf => conf.split("; ?").exists(_.startsWith("test")))
+  }
 
   private def toModuleID(dep: Dependency): ModuleID = ModuleID(
     organization = dep.organization,


### PR DESCRIPTION
We've added a task `unusedCompileDependenciesAggregate`, that aggregates all dependencies for subprojects and checks against one list of dependencies.